### PR TITLE
Fix header for ELPA / MELPA

### DIFF
--- a/moonscript-mode.el
+++ b/moonscript-mode.el
@@ -1,11 +1,21 @@
-;;; moonscript-mode.el --- a simplistic major-mode for editing Moonscript
+;;; moonscript-mode.el --- a major-mode for editing Moonscript
+;;;
+;;; Author: @GriffinSchneider, @k2052, @EmacsFodder
+;;; Version: 20140803-0.1.0
+;;; Commentary:
+;;
+;;  A basic major mode for editing MoonScript, a preprocessed language
+;;  for Lua which shares many similarities with CoffeeScript.
+;;
+;;; License: MIT Licence
+;;
+;;; Code:
 
 (defvar moonscript-keywords
   '("class" "extends" "with" "export" "import" "from" "for" "in"))
 
 (defvar moonscript-keywords-regex (regexp-opt moonscript-keywords 'symbols))
 
-;; Class names - just match any word starting with a capital letter
 (defvar moonscript-class-name-regex "\\<[A-Z]\\w*\\>")
 
 (defvar moonscript-function-keywords
@@ -29,7 +39,7 @@
 
 (defvar moonscript-assignment-var-regex
   (concat "\\(\\_<\\w+\\) = "))
-  
+
 (defvar moonscript-font-lock-defaults
   (eval-when-compile
     `((,moonscript-class-name-regex     . font-lock-type-face)
@@ -54,3 +64,4 @@
 (add-to-list 'auto-mode-alist '("\\.moon$" . moonscript-mode))
 
 (provide 'moonscript-mode)
+;;; moonscript.el ends here

--- a/moonscriptrepl-mode.el
+++ b/moonscriptrepl-mode.el
@@ -1,4 +1,14 @@
-;;; moonscriptrepl-mode.el --- a simplistic major-mode for editing Moonscript in a repl
+;;; moonscriptrepl-mode.el --- a major-mode for editing Moonscript in a repl
+;;
+;;; Author: @GriffinSchneider, @k2052, @EmacsFodder
+;;; Version: 20140803-0.1.0
+;;; Commentary:
+;;
+;;  A basic major mode for MoonScript REPL
+;;
+;;; License: MIT Licence
+;;
+;;; Code:
 
 (require 'moonscript-mode)
 
@@ -10,3 +20,4 @@
   (modify-syntax-entry ?\_ "w" moonscript-mode-syntax-table))
 
 (provide 'moonscriptrepl-mode)
+;;; moonscriptrepl-mode.el ends here


### PR DESCRIPTION
Added ELPA/MELPA compatible packaging, also stripped overly obvious comment from Class name regex.

Changed description from "simplistic" to just major-mode, as it should be.  Simplistic as it may be now, I see it as a seed from which a greater moonscript-mode can grow.
