### PR TITLE
Load cl-lib for using assert macro

### DIFF
--- a/moonscript.el
+++ b/moonscript.el
@@ -1,7 +1,8 @@
 ;;; moonscript.el --- Major mode for editing MoonScript code
 ;;;
-;;; Author: @GriffinSchneider, @k2052, @EmacsFodder
-;;; Version: 20140803-0.1.0
+;; Author: @GriffinSchneider, @k2052, @EmacsFodder
+;; Version: 20140803-0.1.0
+;; Package-Requires: ((cl-lib "0.5"))
 ;;; Commentary:
 ;;
 ;; A basic major mode for editing MoonScript, a preprocessed language
@@ -10,6 +11,8 @@
 ;;; License: MIT Licence
 ;;
 ;;; Code:
+
+(require 'cl-lib)
 
 (defgroup moonscript nil
   "MoonScript (for Lua) language support for Emacs."
@@ -87,7 +90,7 @@
 
 If BLANKVAL is non-nil, return that instead if the line is blank.
 Upon return, regexp match data is set to the leading whitespace."
-  (assert (= (point) (point-at-bol)))
+  (cl-assert (= (point) (point-at-bol)))
   (looking-at "^[ \t]*")
   (if (and blankval (= (match-end 0) (point-at-eol)))
       blankval


### PR DESCRIPTION
- Use cl-lib instead of cl.el
- Add package requirement header
- Fix package header lines. They should has two semicolons, not three.

There are a following warning in original code.
```
In end of data:
moonscript.el:143:1:Warning: the function `assert' is not known to be defined.
```