### PR TITLE
Cleanups suggested by @purcell

### DIFF
--- a/moonscript.el
+++ b/moonscript.el
@@ -122,24 +122,20 @@ re-indenting a line."
                         (1- oldindent))))
       (replace-match (make-string (* newindent moonscript-indent-offset)
                                   ? )))))
-;;;###autoload
-(define-derived-mode moonscript-mode fundamental-mode "MoonScript"
-  (set (make-local-variable 'font-lock-defaults)
-       '(moonscript-font-lock-defaults))
 
+;;;###autoload
+(define-derived-mode moonscript-mode prog-mode "MoonScript"
+  "Major mode for editing MoonScript code."
+  (setq font-lock-defaults '(moonscript-font-lock-defaults))
   (set (make-local-variable 'indent-line-function) 'moonscript-indent-line)
-  (when (fboundp 'electric-indent-local-mode)
-    ;; The electric indent feature re-indents the current line
-    ;; whenever the user types a newline. That doesn't mesh well with
-    ;; languages such as MoonScript that have significant whitespace.
-    (electric-indent-local-mode 0))
+  (set (make-local-variable 'electric-indent-inhibit) t)
   (modify-syntax-entry ?\- ". 12b" moonscript-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" moonscript-mode-syntax-table)
   (modify-syntax-entry ?\_ "w" moonscript-mode-syntax-table))
 
-(provide 'moonscript)
-
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.moon\\'" . moonscript-mode))
+
+(provide 'moonscript)
 
 ;;; moonscript.el ends here


### PR DESCRIPTION
* A better way to disable electric-indent-mode is to set
  electric-indent-inhibit to mark the mode as incompatible with
  electric-indent.
* font-lock-defaults is always buffer-local, so setq is fine: no
  make-local-variable is necessary.
* If you're happy to depend on Emacs 24, prog-mode would be a much
  better parent mode than fundamental-mode.